### PR TITLE
Fix the setTimeout call in registerDevice (MOBILE-837)

### DIFF
--- a/src/windows/PushwooshPluginProxy.js
+++ b/src/windows/PushwooshPluginProxy.js
@@ -34,7 +34,7 @@ module.exports = {
     registerDevice: function (success, fail) {
         if (!this.service) {
             // postpone
-            setTimeout(function () { this.plugins.pushNotification.registerDevice(success, fail) }, 5000);
+            setTimeout(function () { this.plugins.pushNotification.registerDevice(success, fail); }, 5000);
             return;
         }
 

--- a/src/windows/PushwooshPluginProxy.js
+++ b/src/windows/PushwooshPluginProxy.js
@@ -7,18 +7,23 @@ var platform = require('cordova/platform');
 module.exports = {
 
     onDeviceReady: function (success, fail, config) {
-        this.service = new PushSDK.NotificationService.getCurrent(config[0].appid);
+        try {
+            this.service = new PushSDK.NotificationService.getCurrent(config[0].appid);
 
-        var startPushData = null;
+            var startPushData = null;
 
-        if (platform.activationContext && platform.activationContext.args) {
-            startPushData = platform.activationContext.args;
+            if (platform.activationContext && platform.activationContext.args) {
+                startPushData = platform.activationContext.args;
+            }
+
+            if (startPushData !== null)
+                PushSDK.NotificationService.handleStartPush(startPushData);
+
+            success();
         }
-
-        if (startPushData !== null)
-            PushSDK.NotificationService.handleStartPush(startPushData);
-
-        success();
+        catch (e) {
+            fail(e);
+        }
     },
 
     onAppActivated: function (success, fail, args) {
@@ -29,7 +34,8 @@ module.exports = {
     registerDevice: function (success, fail) {
         if (!this.service) {
             // postpone
-            setTimeout(registerDevice, 1000, success, fail);
+            setTimeout(function () { this.plugins.pushNotification.registerDevice(success, fail) }, 5000);
+            return;
         }
 
         this.service.ononpushtokenreceived = function (token) {

--- a/src/windows/PushwooshPluginProxy.js
+++ b/src/windows/PushwooshPluginProxy.js
@@ -9,21 +9,21 @@ module.exports = {
     onDeviceReady: function (success, fail, config) {
         try {
             this.service = new PushSDK.NotificationService.getCurrent(config[0].appid);
-
-            var startPushData = null;
-
-            if (platform.activationContext && platform.activationContext.args) {
-                startPushData = platform.activationContext.args;
-            }
-
-            if (startPushData !== null)
-                PushSDK.NotificationService.handleStartPush(startPushData);
-
-            success();
         }
         catch (e) {
             fail(e);
         }
+
+        var startPushData = null;
+
+        if (platform.activationContext && platform.activationContext.args) {
+            startPushData = platform.activationContext.args;
+        }
+
+        if (startPushData !== null)
+            PushSDK.NotificationService.handleStartPush(startPushData);
+
+        success();
     },
 
     onAppActivated: function (success, fail, args) {

--- a/src/windows/PushwooshPluginProxy.js
+++ b/src/windows/PushwooshPluginProxy.js
@@ -29,7 +29,7 @@ module.exports = {
     registerDevice: function (success, fail) {
         if (!this.service) {
             // postpone
-            setTimeout(function () { this.registerDevice(success, fail) }, 1000);
+            setTimeout(registerDevice, 1000, success, fail);
         }
 
         this.service.ononpushtokenreceived = function (token) {


### PR DESCRIPTION
It appears that in slow systems where `!this.service` was returning `true`, the context for the `setTimeout` call was incorrect as it was throwing an error:

Object doesn't support property or method 'registerDevice'

Because there was no return in that `setTimeout` section, it would then throw another exception further down on the next `this.service` call. So now we have a try/catch written around that which calls into the error callback.